### PR TITLE
upload: Fix data race in Upload() method

### DIFF
--- a/speedtest/upload.go
+++ b/speedtest/upload.go
@@ -87,6 +87,7 @@ func (server *Server) UploadSpeed() int {
 
 	go func() {
 		for _, size := range uploadSizes {
+			size := size // local copy to avoid the data race.
 			for i := 0; i < uploadRepeats; i++ {
 				url := server.URL
 				starterChan <- 1

--- a/speedtest/upload_test.go
+++ b/speedtest/upload_test.go
@@ -1,0 +1,44 @@
+package speedtest
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpload(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Opts
+	}{
+		{
+			name: "default options",
+			opts: Opts{},
+		},
+		{
+			name: "quiet option",
+			opts: Opts{Quiet: true},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// set timeout to avoid the longer tests.
+			tc.opts.Timeout = 10 * time.Second
+			c := NewClient(&tc.opts)
+			if _, err := c.Config(); err != nil {
+				t.Fatalf("unexpected config error: %v", err)
+			}
+			s, err := c.ClosestServers()
+			if err != nil {
+				t.Fatalf("unexpected server selection error: %v", err)
+			}
+			// pick the firstest server to test.
+			upload := s.MeasureLatencies(
+				DefaultLatencyMeasureTimes,
+				DefaultErrorLatency,
+			).First().UploadSpeed()
+			t.Logf("upload %d bps", upload)
+		})
+	}
+}


### PR DESCRIPTION
The patch fixes the following data race:

```
air0$ go test -v -race   ./speedtest                                                                                                                                                                                                                                                                                                     [199/578]
=== RUN   TestUpload
=== RUN   TestUpload/default_options
2018/08/13 13:37:50 Retrieving speedtest.net configuration...
2018/08/13 13:37:50 Retrieving speedtest.net server list...
2018/08/13 13:37:53 Measuring server latencies...
Testing upload speed: ...==================
WARNING: DATA RACE
Write at 0x00c0017416c0 by goroutine 39:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:89 +0x1e9

Previous read at 0x00c0017416c0 by goroutine 41:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1.1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:94 +0x3f

Goroutine 39 (running) created at:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:88 +0x1a2
  github.com/keinohguchi/speedtest-cli/speedtest.TestUpload.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload_test.go:40 +0x1ee
  testing.tRunner()
      /home/kei/git/go/src/testing/testing.go:827 +0x162

Goroutine 41 (running) created at:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:93 +0x17b
==================
.==================
WARNING: DATA RACE
Read at 0x00c0017416c0 by goroutine 107:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1.1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:94 +0x3f

Previous write at 0x00c0017416c0 by goroutine 39:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:89 +0x1e9

Goroutine 107 (running) created at:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:93 +0x17b

Goroutine 39 (running) created at:
  github.com/keinohguchi/speedtest-cli/speedtest.(*Server).UploadSpeed()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload.go:88 +0x1a2
  github.com/keinohguchi/speedtest-cli/speedtest.TestUpload.func1()
      /home/kei/src/github.com/keinohguchi/speedtest-cli/speedtest/upload_test.go:40 +0x1ee
  testing.tRunner()
      /home/kei/git/go/src/testing/testing.go:827 +0x162
==================
........................................................................
=== RUN   TestUpload/quiet
--- FAIL: TestUpload (26.17s)
    --- FAIL: TestUpload/default_options (13.19s)
        upload_test.go:41: upload 3640122 bps
        testing.go:771: race detected during execution of test
    --- PASS: TestUpload/quiet_option (12.97s)
        upload_test.go:41: upload 4679692 bps
    testing.go:771: race detected during execution of test
FAIL
FAIL    github.com/keinohguchi/speedtest-cli/speedtest  26.184s
air0$
```