### PR TITLE
latency: Fix nil access violation when Client.Get() returns error

### DIFF
--- a/speedtest/config.go
+++ b/speedtest/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Times  ConfigTimes `xml:"times"`
 }
 
-func (client *Client) Log(format string, a ...interface{}) {
+func (client *client) Log(format string, a ...interface{}) {
 	if !client.opts.Quiet {
 		log.Printf(format, a...)
 	}
@@ -41,14 +41,14 @@ type ConfigRef struct {
 	Error  error
 }
 
-func (client *Client) Config() (*Config, error) {
+func (client *client) Config() (*Config, error) {
 	configChan := make(chan ConfigRef)
 	client.LoadConfig(configChan)
 	configRef := <-configChan
 	return configRef.Config, configRef.Error
 }
 
-func (client *Client) LoadConfig(ret chan ConfigRef) {
+func (client *client) LoadConfig(ret chan ConfigRef) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
@@ -64,7 +64,7 @@ func (client *Client) LoadConfig(ret chan ConfigRef) {
 	}()
 }
 
-func (client *Client) loadConfig() {
+func (client *client) loadConfig() {
 	client.Log("Retrieving speedtest.net configuration...")
 
 	result := ConfigRef{}

--- a/speedtest/download.go
+++ b/speedtest/download.go
@@ -15,7 +15,7 @@ const downloadRepeats = 5
 
 var downloadImageSizes = []int{350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000}
 
-func (client *Client) downloadFile(url string, start time.Time, ret chan int) {
+func (client *client) downloadFile(url string, start time.Time, ret chan int) {
 	totalRead := 0
 	defer func() {
 		ret <- totalRead
@@ -51,7 +51,7 @@ func (client *Client) downloadFile(url string, start time.Time, ret chan int) {
 }
 
 func (server *Server) DownloadSpeed() int {
-	client := server.client
+	client := server.client.(*client)
 	if !client.opts.Quiet {
 		os.Stdout.WriteString("Testing download speed: ")
 		os.Stdout.Sync()

--- a/speedtest/latency.go
+++ b/speedtest/latency.go
@@ -74,7 +74,7 @@ func (server *Server) measureLatency(errorLatency time.Duration) time.Duration {
 	}
 	if err != nil {
 		server.client.Log("[%s] Failed to detect latency: %v\n", url, err)
-		duration = errorLatency
+		return errorLatency
 	}
 	if resp.StatusCode != 200 {
 		server.client.Log("[%s] Invalid latency detection HTTP status: %d\n", url, resp.StatusCode)

--- a/speedtest/latency_test.go
+++ b/speedtest/latency_test.go
@@ -1,0 +1,68 @@
+package speedtest
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func Test_measureLatency(t *testing.T) {
+	tests := []struct {
+		name   string
+		client Client
+		input  time.Duration
+		want   time.Duration
+	}{
+		{
+			name:   "Client.Get() error with DefaultErrorLatency input",
+			client: &latencyErrorClient{},
+			input:  DefaultErrorLatency,
+			want:   DefaultErrorLatency,
+		},
+		{
+			name:   "Client.Get() error with 10 Second input",
+			client: &latencyErrorClient{},
+			input:  10 * time.Second,
+			want:   10 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{client: tc.client}
+			if got, want := s.measureLatency(tc.input), tc.want; got != want {
+				t.Fatalf("unexpected result:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+		})
+	}
+}
+
+// latencyErrorClient is a client returns error from most of the methods.
+type latencyErrorClient struct{}
+
+func (c *latencyErrorClient) Log(_ string, _ ...interface{}) {}
+func (c *latencyErrorClient) Config() (*Config, error) {
+	return nil, errors.New("Config()")
+}
+func (c *latencyErrorClient) LoadConfig(_ chan ConfigRef) {}
+func (c *latencyErrorClient) NewRequest(_ string, _ string, _ io.Reader) (*http.Request, error) {
+	return nil, errors.New("NewRequest()")
+}
+func (c *latencyErrorClient) Get(_ string) (resp *Response, err error) {
+	return nil, errors.New("Get()")
+}
+func (c *latencyErrorClient) Post(_ string, _ string, _ io.Reader) (*Response, error) {
+	return nil, errors.New("Post()")
+}
+func (c *latencyErrorClient) AllServers() (*Servers, error) {
+	return nil, errors.New("AllServers()")
+}
+func (c *latencyErrorClient) LoadAllServers(_ chan ServersRef) {}
+func (c *latencyErrorClient) ClosestServers() (*Servers, error) {
+	return nil, errors.New("ClosestServers()")
+}
+func (c *latencyErrorClient) LoadClosestServers(_ chan ServersRef) {}

--- a/speedtest/server.go
+++ b/speedtest/server.go
@@ -21,7 +21,7 @@ type Server struct {
 	ID       ServerID `xml:"id,attr"`
 	URL2     string `xml:"url2,attr"`
 	Host     string `xml:"host,attr"`
-	client   *Client `xml:"-"`
+	client   Client `xml:"-"`
 	Distance float64 `xml:"-"`
 	Latency  time.Duration `xml:"-"`
 }
@@ -117,7 +117,7 @@ func (servers *Servers) append(other *Servers) *Servers {
 	return servers
 }
 
-func (servers *Servers) sort(client *Client, config *Config) {
+func (servers *Servers) sort(client Client, config *Config) {
 	for _, server := range servers.List {
 		server.client = client;
 		server.Distance = server.DistanceTo(config.Client.Coordinates)
@@ -146,14 +146,14 @@ var serverURLs = [...]string{
 
 var NoServersError error = errors.New("No servers available")
 
-func (client *Client) AllServers() (*Servers, error) {
+func (client *client) AllServers() (*Servers, error) {
 	serversChan := make(chan ServersRef)
 	client.LoadAllServers(serversChan)
 	serversRef := <-serversChan
 	return serversRef.Servers, serversRef.Error
 }
 
-func (client *Client) LoadAllServers(ret chan ServersRef) {
+func (client *client) LoadAllServers(ret chan ServersRef) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
@@ -169,7 +169,7 @@ func (client *Client) LoadAllServers(ret chan ServersRef) {
 	}()
 }
 
-func (client *Client) loadServers() {
+func (client *client) loadServers() {
 	configChan := make(chan ConfigRef)
 	client.LoadConfig(configChan);
 
@@ -204,7 +204,7 @@ func (client *Client) loadServers() {
 	client.allServers <- result
 }
 
-func (client *Client) loadServersFrom(url string, ret chan *Servers) {
+func (client *client) loadServersFrom(url string, ret chan *Servers) {
 	resp, err := client.Get(url)
 	if resp != nil {
 		url = resp.Request.URL.String()
@@ -220,14 +220,14 @@ func (client *Client) loadServersFrom(url string, ret chan *Servers) {
 	ret <- servers
 }
 
-func (client *Client) ClosestServers() (*Servers, error) {
+func (client *client) ClosestServers() (*Servers, error) {
 	serversChan := make(chan ServersRef)
 	client.LoadClosestServers(serversChan)
 	serversRef := <-serversChan
 	return serversRef.Servers, serversRef.Error
 }
 
-func (client *Client) LoadClosestServers(ret chan ServersRef) {
+func (client *client) LoadClosestServers(ret chan ServersRef) {
 	client.mutex.Lock()
 	defer client.mutex.Unlock()
 
@@ -243,7 +243,7 @@ func (client *Client) LoadClosestServers(ret chan ServersRef) {
 	}()
 }
 
-func (client *Client) loadClosestServers() {
+func (client *client) loadClosestServers() {
 	serversChan := make(chan ServersRef)
 	client.LoadAllServers(serversChan)
 	serversRef := <-serversChan

--- a/speedtest/upload.go
+++ b/speedtest/upload.go
@@ -43,7 +43,7 @@ func (r safeReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func (client *Client) uploadFile(url string, start time.Time, size int, ret chan int) {
+func (client *client) uploadFile(url string, start time.Time, size int, ret chan int) {
 	totalWrote := 0
 	defer func() {
 		ret <- totalWrote
@@ -74,7 +74,7 @@ func (client *Client) uploadFile(url string, start time.Time, size int, ret chan
 }
 
 func (server *Server) UploadSpeed() int {
-	client := server.client
+	client := server.client.(*client)
 	if !client.opts.Quiet {
 		os.Stdout.WriteString("Testing upload speed: ")
 		os.Stdout.Sync()


### PR DESCRIPTION
The first commit is the actual fix.  The second and third commits are for the unit testing purpose.

Without the first commit, we'll crash due to the nil access, as below:

```
air0$ go test -v -run ./
=== RUN   Test_measureLatency
=== RUN   Test_measureLatency/Client.Get()_error_with_DefaultErrorLatency_input
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x65a895]

goroutine 20 [running]:
testing.tRunner.func1(0xc000158200)
        /home/kei/git/go/src/testing/testing.go:792 +0x387
panic(0x6a6a80, 0x9128e0)
        /home/kei/git/go/src/runtime/panic.go:513 +0x1b9
github.com/surol/speedtest-cli/speedtest.(*Server).measureLatency(0xc00003fef8, 0x34630b8a000, 0x4d38d0$
        /home/kei/src/github.com/surol/speedtest-cli/speedtest/latency.go:79 +0x255
github.com/surol/speedtest-cli/speedtest.Test_measureLatency.func1(0xc000158200)
        /home/kei/src/github.com/surol/speedtest-cli/speedtest/latency_test.go:36 +0xa1
testing.tRunner(0xc000158200, 0xc0000907c0)
        /home/kei/git/go/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
        /home/kei/git/go/src/testing/testing.go:878 +0x353
exit status 2
FAIL    github.com/surol/speedtest-cli/speedtest        0.005s
air0$
```